### PR TITLE
Fix refresh ticker dropping operations

### DIFF
--- a/internal/business/persisted_operations/dir_loader.go
+++ b/internal/business/persisted_operations/dir_loader.go
@@ -45,11 +45,11 @@ func (d *DirLoader) Load(_ context.Context) (map[string]string, error) {
 			filePath := filepath.Join(d.path, file.Name())
 			contents, err := os.ReadFile(filePath)
 			if err != nil {
+				d.log.Warn("Error reading file", "err", err)
 				continue
 			}
 
 			err = json.Unmarshal(contents, &result)
-
 			if err != nil {
 				d.log.Warn("error unmarshalling operation file", "filepath", filePath, "err", err)
 				continue

--- a/internal/business/persisted_operations/gcp_storage_loader.go
+++ b/internal/business/persisted_operations/gcp_storage_loader.go
@@ -90,9 +90,11 @@ func (g *GcpStorageLoader) Load(ctx context.Context) error {
 			continue
 		}
 
-		if _, err := io.Copy(file, reader); err != nil {
+		_, err = io.Copy(file, reader)
+		if err != nil {
 			cancel()
 			errs = append(errs, fmt.Errorf("io.Copy: %w", err))
+			_ = reader.Close()
 			continue
 		}
 
@@ -105,7 +107,7 @@ func (g *GcpStorageLoader) Load(ctx context.Context) error {
 		_ = reader.Close()
 	}
 
-	g.log.Info(fmt.Sprintf("Read %d manifest files from bucket", numberOfFilesProcessed))
+	g.log.Info("Read manifest files from bucket", "numFiles", numberOfFilesProcessed, "numErrs", len(errs))
 	reloadFilesGauge.WithLabelValues().Set(float64(numberOfFilesProcessed))
 
 	return errors.Join(errs...)

--- a/internal/business/persisted_operations/persisted_operations.go
+++ b/internal/business/persisted_operations/persisted_operations.go
@@ -261,7 +261,7 @@ func (p *PersistedOperationsHandler) reloadProcessor() {
 				return
 			case <-p.refreshTicker.C:
 				if !p.refreshLock.TryLock() {
-					p.log.Warn("Refresh ticker still runnig while next tick")
+					p.log.Warn("Refresh ticker still running while next tick")
 					continue
 				}
 				err := p.reload()

--- a/internal/business/persisted_operations/persisted_operations.go
+++ b/internal/business/persisted_operations/persisted_operations.go
@@ -138,6 +138,8 @@ func NewPersistedOperations(log *slog.Logger, cfg Config, loader LocalLoader, re
 		if err != nil {
 			return nil, err
 		}
+
+		poh.reloadProcessor()
 	}
 
 	return poh, nil


### PR DESCRIPTION
We found that the remote refreshing of persisted operations would sometimes drop operations from specific files. There seems to be a scenario where a file is correctly downloaded from the remote, and stored locally, but when reading the file right after it would see an empty file still.

This cleans up the code around that mechanism, provides additional protections for concurrent processing and fixes the issue. The applied fix may not be the prettiest, but it does the trick and can be supplied faster than diving into why there is a discrepancy when writing to a file and reading it straight after.