### PR TITLE
Exclude parsing null values from manifests

### DIFF
--- a/internal/business/persisted_operations/dir_loader.go
+++ b/internal/business/persisted_operations/dir_loader.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 // DirLoader loads persisted operations from a filesystem directory
@@ -49,6 +50,11 @@ func (d *DirLoader) Load(_ context.Context) (map[string]string, error) {
 				continue
 			}
 
+			// Dont parse null values as null values causes the result map to be reset to null
+			if isNullValue(contents) {
+				continue
+			}
+
 			err = json.Unmarshal(contents, &result)
 			if err != nil {
 				d.log.Warn("error unmarshalling operation file", "filepath", filePath, "err", err)
@@ -58,4 +64,9 @@ func (d *DirLoader) Load(_ context.Context) (map[string]string, error) {
 	}
 
 	return result, nil
+}
+
+func isNullValue(contents []byte) bool {
+	content := strings.ToLower(string(contents))
+	return strings.TrimSpace(content) == "null"
 }

--- a/internal/business/persisted_operations/dir_loader.go
+++ b/internal/business/persisted_operations/dir_loader.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"log/slog"
+	"maps"
 	"os"
 	"path/filepath"
 )
@@ -50,15 +51,13 @@ func (d *DirLoader) Load(_ context.Context) (map[string]string, error) {
 			}
 
 			var manifestHashes map[string]string
-
 			err = json.Unmarshal(contents, &manifestHashes)
 			if err != nil {
 				d.log.Warn("error unmarshalling operation file", "filepath", filePath, "err", err)
 				continue
 			}
-			for hash, operation := range manifestHashes {
-				result[hash] = operation
-			}
+
+			maps.Copy(result, manifestHashes)
 		}
 	}
 

--- a/internal/business/persisted_operations/dir_loader.go
+++ b/internal/business/persisted_operations/dir_loader.go
@@ -50,7 +50,7 @@ func (d *DirLoader) Load(_ context.Context) (map[string]string, error) {
 				continue
 			}
 
-			// Dont parse null values as null values causes the result map to be reset to null
+			// Dont parse null values, as this causes the hash/operations map to be reset to null
 			if isNullValue(contents) {
 				continue
 			}

--- a/internal/business/persisted_operations/dir_loader.go
+++ b/internal/business/persisted_operations/dir_loader.go
@@ -36,7 +36,7 @@ func (d *DirLoader) Load(_ context.Context) (map[string]string, error) {
 		}
 	}
 
-	var result = map[string]string{}
+	result := map[string]string{}
 
 	for _, file := range files {
 		if file.IsDir() {

--- a/internal/business/persisted_operations/dir_loader.go
+++ b/internal/business/persisted_operations/dir_loader.go
@@ -6,7 +6,6 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
-	"strings"
 )
 
 // DirLoader loads persisted operations from a filesystem directory
@@ -36,7 +35,7 @@ func (d *DirLoader) Load(_ context.Context) (map[string]string, error) {
 		}
 	}
 
-	var result map[string]string
+	var result = map[string]string{}
 
 	for _, file := range files {
 		if file.IsDir() {
@@ -50,23 +49,18 @@ func (d *DirLoader) Load(_ context.Context) (map[string]string, error) {
 				continue
 			}
 
-			// Dont parse null values, as this causes the hash/operations map to be reset to null
-			if isNullValue(contents) {
-				continue
-			}
+			var manifestHashes map[string]string
 
-			err = json.Unmarshal(contents, &result)
+			err = json.Unmarshal(contents, &manifestHashes)
 			if err != nil {
 				d.log.Warn("error unmarshalling operation file", "filepath", filePath, "err", err)
 				continue
+			}
+			for hash, operation := range manifestHashes {
+				result[hash] = operation
 			}
 		}
 	}
 
 	return result, nil
-}
-
-func isNullValue(contents []byte) bool {
-	content := strings.ToLower(string(contents))
-	return strings.TrimSpace(content) == "null"
 }


### PR DESCRIPTION
null values causes the in memory hashes/operaties map to be reset to null