### PR TITLE
add option to enabling graphql error logging

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -35,7 +35,7 @@ func httpServer(log *slog.Logger, cfg *config.Config, shutdown chan os.Signal) e
 	blockFieldSuggestions := block_field_suggestions.NewBlockFieldSuggestionsHandler(cfg.BlockFieldSuggestions)
 	obfuscateUpstreamErrors := obfuscate_upstream_errors.NewObfuscateUpstreamErrors(cfg.ObfuscateUpstreamErrors)
 
-	pxy, err := proxy.NewProxy(cfg.Target, blockFieldSuggestions, obfuscateUpstreamErrors)
+	pxy, err := proxy.NewProxy(cfg.Target, blockFieldSuggestions, obfuscateUpstreamErrors, cfg.Log.LogGraphqlErrors, log)
 	if err != nil {
 		log.Error("ErrorPayload creating proxy", "err", err)
 		return nil

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -35,7 +35,7 @@ func httpServer(log *slog.Logger, cfg *config.Config, shutdown chan os.Signal) e
 	blockFieldSuggestions := block_field_suggestions.NewBlockFieldSuggestionsHandler(cfg.BlockFieldSuggestions)
 	obfuscateUpstreamErrors := obfuscate_upstream_errors.NewObfuscateUpstreamErrors(cfg.ObfuscateUpstreamErrors)
 
-	pxy, err := proxy.NewProxy(cfg.Target, blockFieldSuggestions, obfuscateUpstreamErrors, cfg.Log.LogGraphqlErrors, log)
+	pxy, err := proxy.NewProxy(cfg.Target, blockFieldSuggestions, obfuscateUpstreamErrors, cfg.LogGraphqlErrors, log)
 	if err != nil {
 		log.Error("ErrorPayload creating proxy", "err", err)
 		return nil

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -107,9 +107,11 @@ enforce_post:
   # Enable the feature
   enabled: true
 
+log_graphql_errors: false #enable/disables logging of graphql errors
+
+
 log:
   format: text #text or json
-  log_graphql_errors: false #enable/disables logging of graphql errors
 ```
 
 For a more in-depth view of each option visit the accompanying documentation page of each individual protection.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -106,6 +106,10 @@ max_batch:
 enforce_post:
   # Enable the feature
   enabled: true
+
+log:
+  format: text #text or json
+  log_graphql_errors: false #enable/disables logging of graphql errors
 ```
 
 For a more in-depth view of each option visit the accompanying documentation page of each individual protection.

--- a/internal/app/config/config.go
+++ b/internal/app/config/config.go
@@ -44,6 +44,7 @@ type Config struct {
 	MaxBatch                  batch.Config                   `yaml:"max_batch"`
 	AccessLogging             accesslogging.Config           `yaml:"access_logging"`
 	Log                       log.Config                     `yaml:"log"`
+	LogGraphqlErrors          bool                           `conf:"default:false" yaml:"log_graphql_errors"`
 }
 
 func NewConfig(configPath string) (*Config, error) {

--- a/internal/app/log/log.go
+++ b/internal/app/log/log.go
@@ -6,7 +6,8 @@ import (
 )
 
 type Config struct {
-	Format string `conf:"default:json" yaml:"format"`
+	Format           string `conf:"default:json" yaml:"format"`
+	LogGraphqlErrors bool   `conf:"default:false" yaml:"log_graphql_errors"`
 }
 
 var (

--- a/internal/app/log/log.go
+++ b/internal/app/log/log.go
@@ -6,8 +6,7 @@ import (
 )
 
 type Config struct {
-	Format           string `conf:"default:json" yaml:"format"`
-	LogGraphqlErrors bool   `conf:"default:false" yaml:"log_graphql_errors"`
+	Format string `conf:"default:json" yaml:"format"`
 }
 
 var (

--- a/internal/http/proxy/proxy.go
+++ b/internal/http/proxy/proxy.go
@@ -93,11 +93,13 @@ func modifyResponse(blockFieldSuggestions *block_field_suggestions.BlockFieldSug
 
 func logErrors(payload map[string]interface{}, log *slog.Logger) map[string]interface{} {
 	errorsPayload := payload["errors"]
-	if errorsPayload != nil {
-		var graphqlErrors []GraphqlError
 
-		errorsJson, _ := json.Marshal(errorsPayload)
-		err := json.Unmarshal(errorsJson, &graphqlErrors)
+	if errorsPayload != nil {
+		errorsJSON, _ := json.Marshal(errorsPayload)
+
+		var graphqlErrors []GraphqlError
+		err := json.Unmarshal(errorsJSON, &graphqlErrors)
+
 		if err == nil {
 			for _, graphqlError := range graphqlErrors {
 				log.Error("Error occurred at", "path", strings.Join(graphqlError.Path, "->"), "message", graphqlError.Message)

--- a/internal/http/proxy/proxy.go
+++ b/internal/http/proxy/proxy.go
@@ -11,7 +11,6 @@ import (
 	"net/http/httputil"
 	"net/url"
 	"strconv"
-	"strings"
 	"time"
 )
 
@@ -94,18 +93,20 @@ func modifyResponse(blockFieldSuggestions *block_field_suggestions.BlockFieldSug
 func logErrors(payload map[string]interface{}, log *slog.Logger) map[string]interface{} {
 	errorsPayload := payload["errors"]
 
-	if errorsPayload != nil {
-		errorsJSON, _ := json.Marshal(errorsPayload)
+	log.Info("Error occurred at", "error", errorsPayload)
 
-		var graphqlErrors []GraphqlError
-		err := json.Unmarshal(errorsJSON, &graphqlErrors)
-
-		if err == nil {
-			for _, graphqlError := range graphqlErrors {
-				log.Error("Error occurred at", "path", strings.Join(graphqlError.Path, "->"), "message", graphqlError.Message)
-			}
-		}
-	}
+	//if errorsPayload != nil {
+	//	errorsJSON, _ := json.Marshal(errorsPayload)
+	//
+	//	var graphqlErrors []GraphqlError
+	//	err := json.Unmarshal(errorsJSON, &graphqlErrors)
+	//
+	//	if err == nil {
+	//		for _, graphqlError := range graphqlErrors {
+	//			//log.Info("Error occurred at", "path", strings.Join(graphqlError.Path, "->"), "message", graphqlError.Message)
+	//		}
+	//	}
+	//}
 
 	return payload
 }

--- a/internal/http/proxy/proxy.go
+++ b/internal/http/proxy/proxy.go
@@ -6,10 +6,12 @@ import (
 	"github.com/ldebruijn/graphql-protect/internal/business/rules/block_field_suggestions"
 	"github.com/ldebruijn/graphql-protect/internal/business/rules/obfuscate_upstream_errors"
 	"io"
+	"log/slog"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
 	"strconv"
+	"strings"
 	"time"
 )
 
@@ -24,7 +26,7 @@ type TracingConfig struct {
 	RedactedHeaders []string `yaml:"redacted_headers"`
 }
 
-func NewProxy(cfg Config, blockFieldSuggestions *block_field_suggestions.BlockFieldSuggestionsHandler, obfuscateUpstreamErrors *obfuscate_upstream_errors.ObfuscateUpstreamErrors) (*httputil.ReverseProxy, error) {
+func NewProxy(cfg Config, blockFieldSuggestions *block_field_suggestions.BlockFieldSuggestionsHandler, obfuscateUpstreamErrors *obfuscate_upstream_errors.ObfuscateUpstreamErrors, logGraphqlErrors bool, log *slog.Logger) (*httputil.ReverseProxy, error) {
 	target, err := url.Parse(cfg.Host)
 	if err != nil {
 		return nil, err
@@ -38,13 +40,13 @@ func NewProxy(cfg Config, blockFieldSuggestions *block_field_suggestions.BlockFi
 			r.Out.Host = r.In.Host
 		},
 		Transport:      NewTransport(cfg),
-		ModifyResponse: modifyResponse(blockFieldSuggestions, obfuscateUpstreamErrors), // nolint:bodyclose
+		ModifyResponse: modifyResponse(blockFieldSuggestions, obfuscateUpstreamErrors, logGraphqlErrors, log), // nolint:bodyclose
 	}
 
 	return proxy, nil
 }
 
-func modifyResponse(blockFieldSuggestions *block_field_suggestions.BlockFieldSuggestionsHandler, obfuscateUpstreamErrors *obfuscate_upstream_errors.ObfuscateUpstreamErrors) func(res *http.Response) error {
+func modifyResponse(blockFieldSuggestions *block_field_suggestions.BlockFieldSuggestionsHandler, obfuscateUpstreamErrors *obfuscate_upstream_errors.ObfuscateUpstreamErrors, logGraphqlErrors bool, log *slog.Logger) func(res *http.Response) error {
 	return func(res *http.Response) error {
 
 		// read raw response bytes
@@ -58,6 +60,10 @@ func modifyResponse(blockFieldSuggestions *block_field_suggestions.BlockFieldSug
 			// make sure to set body back to original bytes
 			res.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
 			return nil
+		}
+
+		if logGraphqlErrors {
+			logErrors(response, log)
 		}
 
 		if blockFieldSuggestions != nil && blockFieldSuggestions.Enabled() {
@@ -83,4 +89,27 @@ func modifyResponse(blockFieldSuggestions *block_field_suggestions.BlockFieldSug
 
 		return nil
 	}
+}
+
+func logErrors(payload map[string]interface{}, log *slog.Logger) map[string]interface{} {
+	errorsPayload := payload["errors"]
+	if errorsPayload != nil {
+		var graphqlErrors []GraphqlError
+
+		errorsJson, _ := json.Marshal(errorsPayload)
+		err := json.Unmarshal(errorsJson, &graphqlErrors)
+		if err == nil {
+			for _, graphqlError := range graphqlErrors {
+				log.Error("Error occurred at", "path", strings.Join(graphqlError.Path, "->"), "message", graphqlError.Message)
+			}
+		}
+	}
+
+	return payload
+}
+
+type GraphqlError struct {
+	Message    string   `json:"message,omitempty"`
+	Path       []string `json:"path,omitempty"`
+	Extensions any      `json:"extensions,omitempty"`
 }

--- a/internal/http/proxy/proxy.go
+++ b/internal/http/proxy/proxy.go
@@ -89,9 +89,3 @@ func modifyResponse(blockFieldSuggestions *block_field_suggestions.BlockFieldSug
 		return nil
 	}
 }
-
-type GraphqlError struct {
-	Message    string   `json:"message,omitempty"`
-	Path       []string `json:"path,omitempty"`
-	Extensions any      `json:"extensions,omitempty"`
-}

--- a/internal/http/proxy/proxy.go
+++ b/internal/http/proxy/proxy.go
@@ -62,7 +62,7 @@ func modifyResponse(blockFieldSuggestions *block_field_suggestions.BlockFieldSug
 		}
 
 		if logGraphqlErrors {
-			logErrors(response, log)
+			log.Info("Error occurred at", "error", response["errors"])
 		}
 
 		if blockFieldSuggestions != nil && blockFieldSuggestions.Enabled() {
@@ -88,27 +88,6 @@ func modifyResponse(blockFieldSuggestions *block_field_suggestions.BlockFieldSug
 
 		return nil
 	}
-}
-
-func logErrors(payload map[string]interface{}, log *slog.Logger) map[string]interface{} {
-	errorsPayload := payload["errors"]
-
-	log.Info("Error occurred at", "error", errorsPayload)
-
-	//if errorsPayload != nil {
-	//	errorsJSON, _ := json.Marshal(errorsPayload)
-	//
-	//	var graphqlErrors []GraphqlError
-	//	err := json.Unmarshal(errorsJSON, &graphqlErrors)
-	//
-	//	if err == nil {
-	//		for _, graphqlError := range graphqlErrors {
-	//			//log.Info("Error occurred at", "path", strings.Join(graphqlError.Path, "->"), "message", graphqlError.Message)
-	//		}
-	//	}
-	//}
-
-	return payload
 }
 
 type GraphqlError struct {

--- a/internal/http/proxy/proxy_test.go
+++ b/internal/http/proxy/proxy_test.go
@@ -138,7 +138,7 @@ func Test_modifyResponse(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(_ *testing.T) {
-			result := modifyResponse(tt.args.blockFieldSuggestions, nil) // nolint:bodyclose
+			result := modifyResponse(tt.args.blockFieldSuggestions, nil, false, nil) // nolint:bodyclose
 
 			_ = result(tt.args.response)
 			tt.want(tt.args.response)
@@ -158,7 +158,7 @@ func TestForwardsXff(t *testing.T) {
 		Host:      "http://" + upstreamURL.Host,
 		Tracing:   TracingConfig{},
 	}
-	proxy, err := NewProxy(cfg, nil, nil)
+	proxy, err := NewProxy(cfg, nil, nil, false, nil)
 	assert.NoError(t, err)
 
 	req := httptest.NewRequest(http.MethodGet, "/", nil)


### PR DESCRIPTION
adds an option to enable graphql errors.

Specifically for each graphql error in the 'errors' part of a graphql response a logline will be printed e.g.

Error occurred at path=book->author message="upstream 404 error occurred"