### PR TITLE
feat(batch-rule)!: Lower default max batch rule size from 5 to 1

### DIFF
--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -537,6 +537,7 @@ type Product {
 }
 `,
 				cfgOverrides: func(cfg *config.Config) *config.Config {
+					cfg.MaxBatch.Max = 3
 					return cfg
 				},
 				mockResponse: []map[string]interface{}{

--- a/internal/business/rules/batch/batch.go
+++ b/internal/business/rules/batch/batch.go
@@ -29,7 +29,7 @@ type Config struct {
 func DefaultConfig() Config {
 	return Config{
 		Enabled:         true,
-		Max:             5,
+		Max:             1,
 		RejectOnFailure: true,
 	}
 }


### PR DESCRIPTION
I feel batching can be a foot gun. To prevent accidental vulnerability I'm lowering the default maximum batch size to 1. In case users want to use this feature they can still increase it, but it protects users by default by disallowing batches.