### PR TITLE
implement recovery from errors while loading trusted documents

### DIFF
--- a/internal/business/trusteddocuments/persisted_operations.go
+++ b/internal/business/trusteddocuments/persisted_operations.go
@@ -270,6 +270,7 @@ func (p *Handler) Validate(validate func(operation string) gqlerror.List) []vali
 func (p *Handler) load(failureStrategy ReloadFailureStrategy) error {
 	newState, err := p.loader.Load(context.Background())
 	if err != nil {
+		p.log.Error("error loading persisted operations", err)
 		loadingResultCounter.WithLabelValues(p.loader.Type(), "failure").Inc()
 		if failureStrategy == ReloadFailureStrategyReject {
 			return err
@@ -305,10 +306,10 @@ func (p *Handler) reloadProcessor() {
 					continue
 				}
 				err := p.load(ReloadFailureStrategyReject)
+				p.refreshLock.Unlock()
 				if err != nil {
 					continue
 				}
-				p.refreshLock.Unlock()
 			}
 		}
 	}()

--- a/internal/business/trusteddocuments/persisted_operations.go
+++ b/internal/business/trusteddocuments/persisted_operations.go
@@ -270,7 +270,7 @@ func (p *Handler) Validate(validate func(operation string) gqlerror.List) []vali
 func (p *Handler) load(failureStrategy ReloadFailureStrategy) error {
 	newState, err := p.loader.Load(context.Background())
 	if err != nil {
-		p.log.Error("error loading persisted operations", err)
+		p.log.Error("error loading persisted operations", "err", err)
 		loadingResultCounter.WithLabelValues(p.loader.Type(), "failure").Inc()
 		if failureStrategy == ReloadFailureStrategyReject {
 			return err


### PR DESCRIPTION
Once an error occurred during the process of loading trusted docs it never unlocked the lock causing it to never re-load trusted documents again

( +added some logging about the error)