### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -3,6 +3,9 @@
 
 name: Go
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "main" ]


### PR DESCRIPTION
Potential fix for [https://github.com/ldebruijn/graphql-protect/security/code-scanning/1](https://github.com/ldebruijn/graphql-protect/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root level of the workflow. This block will apply to all jobs in the workflow. Since the workflow only builds and tests the Go project, it does not require any write permissions. The minimal required permission is `contents: read`, which allows the workflow to read the repository contents.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
