### PR TITLE
feat: add async option to access logging

### DIFF
--- a/docs/protections/access_logging.md
+++ b/docs/protections/access_logging.md
@@ -35,4 +35,4 @@ For each operation we'll produce an access log record according to your provided
 If used in conjunction with persisted operations the access log will be produced after the operation is swapped for the payload, meaning you have full access to the operation name and payload.
 
 If async is enabled, every access log record will be put on a channel and the logging is processed async. This way there is no waiting for slog to actually log the entry, but the request can be proxied immediately after. The amount of requests that can be buffered is configurable.
-A metric is available to see if you buffer overflows and logs are dropped. If this number is going up, you need to increase your buffersize.
+Metrics are available to see if you buffer overflows and logs are dropped, and how much of your configured buffer size is used. If this number is going up, you need to increase your buffersize.

--- a/docs/protections/access_logging.md
+++ b/docs/protections/access_logging.md
@@ -22,6 +22,10 @@ access_logging:
   include_variables: true
   # Include the payload in the access log record
   include_payload: true
+  # Set to true to utilize async access-logging
+  async: true
+  # Set the buffer size of how many log entries can be buffered
+  buffer_size: 1000
 ```
 
 ## How does it work?
@@ -29,3 +33,6 @@ access_logging:
 For each operation we'll produce an access log record according to your provided configuration. 
 
 If used in conjunction with persisted operations the access log will be produced after the operation is swapped for the payload, meaning you have full access to the operation name and payload.
+
+If async is enabled, every access log record will be put on a channel and the logging is processed async. This way there is no waiting for slog to actually log the entry, but the request can be proxied immediately after. The amount of requests that can be buffered is configurable.
+A metric is available to see if you buffer overflows and logs are dropped. If this number is going up, you need to increase your buffersize.

--- a/internal/app/config/config_test.go
+++ b/internal/app/config/config_test.go
@@ -1,6 +1,10 @@
 package config
 
 import (
+	"os"
+	"testing"
+	"time"
+
 	"github.com/ldebruijn/graphql-protect/internal/app/http"
 	"github.com/ldebruijn/graphql-protect/internal/app/log"
 	"github.com/ldebruijn/graphql-protect/internal/business/rules/accesslogging"
@@ -15,9 +19,6 @@ import (
 	"github.com/ldebruijn/graphql-protect/internal/http/proxy"
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/yaml.v3"
-	"os"
-	"testing"
-	"time"
 )
 
 func TestNewConfig(t *testing.T) {
@@ -211,6 +212,8 @@ log:
 					IncludeOperationName: false,
 					IncludeVariables:     false,
 					IncludePayload:       true,
+					Async:                false,
+					BufferSize:           1000,
 				},
 				Log: log.Config{
 					Format: log.TextFormat,

--- a/internal/business/rules/accesslogging/accesslogging.go
+++ b/internal/business/rules/accesslogging/accesslogging.go
@@ -11,14 +11,12 @@ import (
 )
 
 var (
-	droppedLogsCounter = prometheus.NewCounterVec(prometheus.CounterOpts{
+	droppedLogsCounter = prometheus.NewCounter(prometheus.CounterOpts{
 		Namespace: "graphql_protect",
 		Subsystem: "access_logging",
 		Name:      "dropped_logs_total",
 		Help:      "The total number of access log entries dropped due to full channel buffer",
-	},
-		[]string{"reason"},
-	)
+	})
 )
 
 func init() {
@@ -102,7 +100,7 @@ func (a *AccessLogging) Log(payloads []gql.RequestData, headers http.Header) {
 			// Successfully queued
 		default:
 			// Channel is full, drop the log entry to avoid blocking
-			droppedLogsCounter.WithLabelValues("channel_full").Inc()
+			droppedLogsCounter.Inc()
 		}
 	} else {
 		// Synchronous logging (original behavior)

--- a/internal/business/rules/accesslogging/accesslogging.go
+++ b/internal/business/rules/accesslogging/accesslogging.go
@@ -1,10 +1,29 @@
 package accesslogging
 
 import (
-	"github.com/ldebruijn/graphql-protect/internal/business/gql"
+	"context"
 	"log/slog"
 	"net/http"
+	"sync"
+
+	"github.com/ldebruijn/graphql-protect/internal/business/gql"
+	"github.com/prometheus/client_golang/prometheus"
 )
+
+var (
+	droppedLogsCounter = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "graphql_protect",
+		Subsystem: "access_logging",
+		Name:      "dropped_logs_total",
+		Help:      "The total number of access log entries dropped due to full channel buffer",
+	},
+		[]string{"reason"},
+	)
+)
+
+func init() {
+	prometheus.MustRegister(droppedLogsCounter)
+}
 
 type Config struct {
 	Enabled              bool     `yaml:"enabled"`
@@ -12,6 +31,8 @@ type Config struct {
 	IncludeOperationName bool     `yaml:"include_operation_name"`
 	IncludeVariables     bool     `yaml:"include_variables"`
 	IncludePayload       bool     `yaml:"include_payload"`
+	Async                bool     `yaml:"async"`
+	BufferSize           int      `yaml:"buffer_size"`
 }
 
 func DefaultConfig() Config {
@@ -21,7 +42,14 @@ func DefaultConfig() Config {
 		IncludeOperationName: true,
 		IncludeVariables:     true,
 		IncludePayload:       false,
+		Async:                false,
+		BufferSize:           1000,
 	}
+}
+
+type logEntry struct {
+	payloads []gql.RequestData
+	headers  http.Header
 }
 
 type AccessLogging struct {
@@ -31,6 +59,10 @@ type AccessLogging struct {
 	includeOperationName bool
 	includeVariables     bool
 	includePayload       bool
+	async                bool
+	logChan              chan logEntry
+	shutdown             chan struct{}
+	wg                   sync.WaitGroup
 }
 
 func NewAccessLogging(cfg Config, log *slog.Logger) *AccessLogging {
@@ -39,14 +71,23 @@ func NewAccessLogging(cfg Config, log *slog.Logger) *AccessLogging {
 		headers[header] = true
 	}
 
-	return &AccessLogging{
+	al := &AccessLogging{
 		log:                  log.WithGroup("access-logging"),
 		enabled:              cfg.Enabled,
 		includeHeaders:       headers,
 		includeOperationName: cfg.IncludeOperationName,
 		includeVariables:     cfg.IncludeVariables,
 		includePayload:       cfg.IncludePayload,
+		async:                cfg.Async,
+		shutdown:             make(chan struct{}),
 	}
+
+	if cfg.Async && cfg.Enabled {
+		al.logChan = make(chan logEntry, cfg.BufferSize)
+		al.startAsyncLogger()
+	}
+
+	return al
 }
 
 func (a *AccessLogging) Log(payloads []gql.RequestData, headers http.Header) {
@@ -54,6 +95,22 @@ func (a *AccessLogging) Log(payloads []gql.RequestData, headers http.Header) {
 		return
 	}
 
+	if a.async {
+		// Non-blocking send to channel
+		select {
+		case a.logChan <- logEntry{payloads: payloads, headers: headers}:
+			// Successfully queued
+		default:
+			// Channel is full, drop the log entry to avoid blocking
+			droppedLogsCounter.WithLabelValues("channel_full").Inc()
+		}
+	} else {
+		// Synchronous logging (original behavior)
+		a.logSync(payloads, headers)
+	}
+}
+
+func (a *AccessLogging) logSync(payloads []gql.RequestData, headers http.Header) {
 	headersToInclude := map[string]interface{}{}
 	for key := range a.includeHeaders {
 		headersToInclude[key] = headers.Values(key)
@@ -75,5 +132,52 @@ func (a *AccessLogging) Log(payloads []gql.RequestData, headers http.Header) {
 		al.WithHeaders(headersToInclude)
 
 		a.log.Info("record", "payload", al)
+	}
+}
+
+func (a *AccessLogging) startAsyncLogger() {
+	a.wg.Go(func() {
+		for {
+			select {
+			case entry := <-a.logChan:
+				// Process each log entry immediately
+				a.logSync(entry.payloads, entry.headers)
+
+			case <-a.shutdown:
+				// Drain remaining entries and exit
+				for {
+					select {
+					case entry := <-a.logChan:
+						a.logSync(entry.payloads, entry.headers)
+					default:
+						return
+					}
+				}
+			}
+		}
+	})
+}
+
+// Shutdown gracefully stops the async logger
+func (a *AccessLogging) Shutdown(ctx context.Context) error {
+	if !a.async || !a.enabled {
+		return nil
+	}
+
+	// Signal shutdown
+	close(a.shutdown)
+
+	// Wait for goroutine to finish with timeout
+	done := make(chan struct{})
+	go func() {
+		a.wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
 	}
 }


### PR DESCRIPTION
This PR solves the following issue:

After adding more spans to the tracing output, we noticed that when we noticed p99 latency issues on our GraphQL endpoint, the most time was spent on the access-logging part of the request, the other validations were pretty fast.

Reading up on how slog works with stdout, is that it contains a lock, and also os.Stdout is having a fixed buffer size, and underlying systems like the Linux kernel and perhaps even the container-runtime all also have possibly limitations on how much you can throw at stdout. 

To fix this buffering, and remove it from the hot path, in this PR a new buffer (no pun intended) is created, so it can throw the request onto that buffer, and move forward with processing the rest of the request. A separate goroutine is then responsible for actually writing all the buffered entries out to the logger again, which then is allowed to take as long as it needs.

Some metrics are added to see how full the buffers are and whether we still need to drop logs or not.
