### PR TITLE
fix(access-logs): Buffer logging to stdout to prevent backpressure

### DIFF
--- a/internal/business/rules/accesslogging/accesslogging.go
+++ b/internal/business/rules/accesslogging/accesslogging.go
@@ -87,7 +87,7 @@ func NewAccessLogging(cfg Config, log *slog.Logger) *AccessLogging {
 	}
 
 	// construct a buffered writer on stdout to prevent backpressure on stdout from heavy access logs volumes
-	stdoutWriter := bufio.NewWriter(os.Stdout)
+	stdoutWriter := bufio.NewWriterSize(os.Stdout, cfg.BufferSize)
 	if !cfg.Async {
 		// use buffered stdout writer for access logs, always use json format for access logs
 		log = slog.New(slog.NewJSONHandler(stdoutWriter, nil)).WithGroup("access-logging")

--- a/internal/business/rules/accesslogging/accesslogging.go
+++ b/internal/business/rules/accesslogging/accesslogging.go
@@ -90,11 +90,11 @@ func NewAccessLogging(cfg Config, log *slog.Logger) *AccessLogging {
 	stdoutWriter := bufio.NewWriterSize(os.Stdout, cfg.BufferSize)
 	if !cfg.Async {
 		// use buffered stdout writer for access logs, always use json format for access logs
-		log = slog.New(slog.NewJSONHandler(stdoutWriter, nil)).WithGroup("access-logging")
+		log = slog.New(slog.NewJSONHandler(stdoutWriter, nil))
 	}
 
 	al := &AccessLogging{
-		log:                  log,
+		log:                  log.WithGroup("access-logging"),
 		enabled:              cfg.Enabled,
 		includeHeaders:       headers,
 		includeOperationName: cfg.IncludeOperationName,


### PR DESCRIPTION
Adjust the access logging logger to use a buffered writer, to prevent stdout from creating backpressure onto the application. Theory being that logging more logs once has less impact on stdout than logging smaller log lines often.

The buffer size is configurable.

This changeset is an iteration on #212 