### PR TITLE
feat(max-aliases): add per-operation override support

### DIFF
--- a/internal/app/config/config_test.go
+++ b/internal/app/config/config_test.go
@@ -185,6 +185,7 @@ log:
 					Enabled:         false,
 					Max:             1,
 					RejectOnFailure: false,
+					Overrides:       map[string]int{},
 				},
 				EnforcePost: enforce_post.Config{
 					Enabled: false,

--- a/internal/business/rules/aliases/aliases.go
+++ b/internal/business/rules/aliases/aliases.go
@@ -21,9 +21,10 @@ var (
 )
 
 type Config struct {
-	Enabled         bool `yaml:"enabled"`
-	Max             int  `yaml:"max"`
-	RejectOnFailure bool `yaml:"reject_on_failure"`
+	Enabled         bool           `yaml:"enabled"`
+	Max             int            `yaml:"max"`
+	RejectOnFailure bool           `yaml:"reject_on_failure"`
+	Overrides       map[string]int `yaml:"overrides"`
 }
 
 func DefaultConfig() Config {
@@ -31,6 +32,7 @@ func DefaultConfig() Config {
 		Enabled:         true,
 		Max:             15,
 		RejectOnFailure: true,
+		Overrides:       make(map[string]int),
 	}
 }
 
@@ -58,13 +60,18 @@ func NewMaxAliasesRule(cfg Config, rules *validatorrules.Rules) {
 			observers.OnOperation(func(_ *validator.Walker, operation *ast.OperationDefinition) {
 				aliases += countAliases(operation)
 
-				if aliases > cfg.Max {
+				maxAliases := cfg.Max
+				if override, ok := cfg.Overrides[operation.Name]; ok {
+					maxAliases = override
+				}
+
+				if aliases > maxAliases {
 					if cfg.RejectOnFailure {
 						addError(validation.RuleValidationResult{
 							Rule:          "max-aliases",
 							OperationName: operation.Name,
 							Result:        validation.REJECTED,
-							Message:       fmt.Sprintf("aliases limit of %d exceeded, found %d", cfg.Max, aliases),
+							Message:       fmt.Sprintf("aliases limit of %d exceeded, found %d", maxAliases, aliases),
 						}.Wrap())
 						resultCounter.WithLabelValues("rejected").Inc()
 					} else {
@@ -72,7 +79,7 @@ func NewMaxAliasesRule(cfg Config, rules *validatorrules.Rules) {
 							Rule:          "max-aliases",
 							OperationName: operation.Name,
 							Result:        validation.FAILED,
-							Message:       fmt.Sprintf("aliases limit of %d exceeded, found %d", cfg.Max, aliases),
+							Message:       fmt.Sprintf("aliases limit of %d exceeded, found %d", maxAliases, aliases),
 						}.Wrap())
 						resultCounter.WithLabelValues("failed").Inc()
 					}

--- a/internal/business/rules/aliases/aliases_test.go
+++ b/internal/business/rules/aliases/aliases_test.go
@@ -95,6 +95,85 @@ type Book {
 			}.AsGqlError(),
 		},
 		{
+			name: "override allows more aliases for named operation",
+			args: args{
+				query: `query MyOp {
+    firstBooks: getBook(title: "null") {
+      author
+      title
+    }
+    secondBooks: getBook(title: "null") {
+      author
+      title
+    }
+  }`,
+				schema: schema,
+				cfg: Config{
+					Max:             1,
+					Enabled:         true,
+					RejectOnFailure: true,
+					Overrides:       map[string]int{"MyOp": 5},
+				},
+			},
+			want: nil,
+		},
+		{
+			name: "override allows fewer aliases for named operation",
+			args: args{
+				query: `query MyOp {
+    firstBooks: getBook(title: "null") {
+      author
+      title
+    }
+    secondBooks: getBook(title: "null") {
+      author
+      title
+    }
+  }`,
+				schema: schema,
+				cfg: Config{
+					Max:             15,
+					Enabled:         true,
+					RejectOnFailure: true,
+					Overrides:       map[string]int{"MyOp": 1},
+				},
+			},
+			want: validation.RuleValidationResult{
+				Rule:          "max-aliases",
+				OperationName: "MyOp",
+				Result:        validation.REJECTED,
+				Message:       fmt.Sprintf("aliases limit of %d exceeded, found %d", 1, 2),
+			}.AsGqlError(),
+		},
+		{
+			name: "override does not apply to other operations",
+			args: args{
+				query: `query OtherOp {
+    firstBooks: getBook(title: "null") {
+      author
+      title
+    }
+    secondBooks: getBook(title: "null") {
+      author
+      title
+    }
+  }`,
+				schema: schema,
+				cfg: Config{
+					Max:             1,
+					Enabled:         true,
+					RejectOnFailure: true,
+					Overrides:       map[string]int{"MyOp": 5},
+				},
+			},
+			want: validation.RuleValidationResult{
+				Rule:          "max-aliases",
+				OperationName: "OtherOp",
+				Result:        validation.REJECTED,
+				Message:       fmt.Sprintf("aliases limit of %d exceeded, found %d", 1, 2),
+			}.AsGqlError(),
+		},
+		{
 			name: "respects fragment aliases",
 			args: args{
 				query: `query A {


### PR DESCRIPTION
## Summary

- Adds an `overrides` map to the `max_aliases` config, allowing per-operation alias limits that take precedence over the global `max` value
- Mirrors the existing override mechanism already present in the `max_tokens` rule
- Initializes `Overrides` to an empty map in `DefaultConfig()` so existing configs without the field are unaffected
- Updates the config snapshot test to include the new `Overrides` field in the expected `MaxAliases` value

## Usage

```yaml
max_aliases:
  enabled: true
  max: 15
  reject_on_failure: true
  overrides:
    MyExpensiveOperation: 30
    TrustedInternalOp: 0
```

## Test plan

- [x] Override allows more aliases for a named operation
- [x] Override allows fewer aliases for a named operation
- [x] Override does not affect other operations not listed in the map
- [x] Config snapshot test updated to reflect new `Overrides` field
- [x] All existing tests still pass (`make test`)

PR created using Claude Code