### PR TITLE
feat: Security fixes, data races, and correctness bugs

### DIFF
--- a/internal/business/gql/gql.go
+++ b/internal/business/gql/gql.go
@@ -41,7 +41,8 @@ type PersistedQuery struct {
 }
 
 func ParseRequestPayload(r *http.Request) ([]RequestData, error) {
-	if r.ContentLength < 1 {
+	// ContentLength == 0 means empty body; -1 means unknown (e.g. chunked encoding) so we must read it.
+	if r.ContentLength == 0 {
 		return []RequestData{}, nil
 	}
 
@@ -56,6 +57,9 @@ func ParseRequestPayload(r *http.Request) ([]RequestData, error) {
 	r.Body = io.NopCloser(bytes.NewBuffer(body))
 
 	body = bytes.TrimSpace(body)
+	if len(body) == 0 {
+		return []RequestData{}, nil
+	}
 	// assume it's a batch request
 	if body[0] == '[' {
 		var data []RequestData

--- a/internal/business/gql/gql_test.go
+++ b/internal/business/gql/gql_test.go
@@ -107,6 +107,32 @@ func TestParseRequestPayload(t *testing.T) {
 			want:    []RequestData{},
 			wantErr: false,
 		},
+		{
+			name: "Handles whitespace-only body without panicking",
+			args: args{
+				r: func() *http.Request {
+					body := bytes.NewBuffer([]byte("   \t\n  "))
+					return httptest.NewRequest("POST", "/graphql", body)
+				}(),
+			},
+			want:    []RequestData{},
+			wantErr: false,
+		},
+		{
+			name: "Handles chunked body (ContentLength -1) without bypassing validation",
+			args: args{
+				r: func() *http.Request {
+					body := bytes.NewBuffer([]byte(`{"query":"{ __typename }"}`))
+					req := httptest.NewRequest("POST", "/graphql", body)
+					req.ContentLength = -1
+					return req
+				}(),
+			},
+			want: []RequestData{
+				{Query: "{ __typename }"},
+			},
+			wantErr: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/business/protect/protect.go
+++ b/internal/business/protect/protect.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"strings"
 	"time"
 
 	"fmt"
@@ -50,6 +51,10 @@ type GraphQLProtect struct {
 func NewGraphQLProtect(log *slog.Logger, cfg *config.Config, po *trusteddocuments.Handler, schema *schema.Provider, upstreamHandler http.Handler) (*GraphQLProtect, error) {
 	rules := validatorrules.NewDefaultRules()
 
+	if cfg.BlockFieldSuggestions.Enabled {
+		rules.ReplaceRule("FieldsOnCorrectType", validatorrules.FieldsOnCorrectTypeRuleWithoutSuggestions.RuleFunc)
+	}
+
 	aliases.NewMaxAliasesRule(cfg.MaxAliases, rules)
 	max_depth.NewMaxDepthRule(cfg.MaxDepth, rules)
 	maxBatch, err := batch.NewMaxBatch(cfg.MaxBatch)
@@ -80,6 +85,13 @@ func NewGraphQLProtect(log *slog.Logger, cfg *config.Config, po *trusteddocument
 }
 
 func (p *GraphQLProtect) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if strings.EqualFold(r.Header.Get("Upgrade"), "websocket") {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"errors":[{"message":"websocket connections are not supported"}]}`))
+		return
+	}
+
 	ctx := r.Context()
 
 	// Create timing context if not already present (middleware normally provides this)

--- a/internal/business/protect/protect_test.go
+++ b/internal/business/protect/protect_test.go
@@ -1,13 +1,6 @@
 package protect
 
 import (
-	"github.com/ldebruijn/graphql-protect/internal/app/config"
-	_http "github.com/ldebruijn/graphql-protect/internal/app/http"
-	"github.com/ldebruijn/graphql-protect/internal/business/rules/accesslogging"
-	"github.com/ldebruijn/graphql-protect/internal/business/rules/batch"
-	"github.com/ldebruijn/graphql-protect/internal/business/rules/tokens"
-	"github.com/ldebruijn/graphql-protect/internal/business/schema"
-	"github.com/stretchr/testify/assert"
 	"io"
 	"log/slog"
 	"net/http"
@@ -16,6 +9,17 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/ldebruijn/graphql-protect/internal/app/config"
+	_http "github.com/ldebruijn/graphql-protect/internal/app/http"
+	"github.com/ldebruijn/graphql-protect/internal/business/rules/accesslogging"
+	"github.com/ldebruijn/graphql-protect/internal/business/rules/batch"
+	block_field_suggestions "github.com/ldebruijn/graphql-protect/internal/business/rules/block_field_suggestions"
+	"github.com/ldebruijn/graphql-protect/internal/business/rules/tokens"
+	"github.com/ldebruijn/graphql-protect/internal/business/schema"
+	"github.com/ldebruijn/graphql-protect/internal/business/trusteddocuments"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func mustNewAccessLogging(cfg accesslogging.Config, log *slog.Logger) *accesslogging.AccessLogging {
@@ -346,4 +350,73 @@ func TestGraphQLProtect_DurationCalculation(t *testing.T) {
 
 	// Verify protect duration is positive
 	assert.Greater(t, protectDuration, time.Duration(0), "Protect duration should be positive")
+}
+
+func TestGraphQLProtect_BlocksWebSocketUpgrades(t *testing.T) {
+	log := slog.Default()
+	schemaProvider := createTestSchemaProvider(t)
+
+	maxBatch, _ := batch.NewMaxBatch(batch.Config{Enabled: true, Max: 10, RejectOnFailure: true})
+
+	p := &GraphQLProtect{
+		log:           log,
+		cfg:           &config.Config{},
+		schema:        schemaProvider,
+		maxBatch:      maxBatch,
+		tokens:        tokens.MaxTokens(tokens.DefaultConfig()),
+		accessLogging: mustNewAccessLogging(accesslogging.Config{}, log),
+		next:          &noop{},
+		preFilterChain: func(next http.Handler) http.Handler {
+			return next
+		},
+	}
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("GET", "/graphql", nil)
+	r.Header.Set("Upgrade", "websocket")
+	r.Header.Set("Connection", "Upgrade")
+
+	p.ServeHTTP(w, r)
+
+	assert.Equal(t, http.StatusBadRequest, w.Result().StatusCode)
+	body, _ := io.ReadAll(w.Result().Body)
+	assert.Contains(t, string(body), "websocket")
+}
+
+func TestNewGraphQLProtect_BlockFieldSuggestionsEnabled_NoSuggestionsInValidationErrors(t *testing.T) {
+	log := slog.Default()
+	schemaProvider := createTestSchemaProvider(t)
+
+	noopLoader, err := trusteddocuments.NewNoOpLoader()
+	require.NoError(t, err)
+	po, err := trusteddocuments.NewPersistedOperations(log, trusteddocuments.Config{
+		Enabled: false,
+		Loader: trusteddocuments.LoaderConfig{
+			Reload: struct {
+				Enabled  bool          `yaml:"enabled"`
+				Interval time.Duration `yaml:"interval"`
+				Timeout  time.Duration `yaml:"timeout"`
+			}{Enabled: false},
+		},
+	}, noopLoader)
+	require.NoError(t, err)
+
+	cfg := &config.Config{
+		BlockFieldSuggestions: block_field_suggestions.Config{
+			Enabled: true,
+			Mask:    "[redacted]",
+		},
+	}
+
+	p, err := NewGraphQLProtect(log, cfg, po, schemaProvider, &noop{})
+	require.NoError(t, err)
+
+	// "hell" is close enough to "hello" that gqlparser would normally suggest it.
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("POST", "/graphql", strings.NewReader(`{"query":"{ hell }"}`))
+	p.ServeHTTP(w, r)
+
+	body, _ := io.ReadAll(w.Result().Body)
+	assert.NotContains(t, string(body), "Did you mean",
+		"protect-layer validation errors must not leak field suggestions when BlockFieldSuggestions is enabled")
 }

--- a/internal/business/rules/aliases/aliases.go
+++ b/internal/business/rules/aliases/aliases.go
@@ -43,9 +43,12 @@ func init() {
 func NewMaxAliasesRule(cfg Config, rules *validatorrules.Rules) {
 	if cfg.Enabled {
 		rules.AddRule("MaxAliases", func(observers *validator.Events, addError validator.AddErrFunc) {
-			aliases := 0
-			// keep track of # of aliases per fragment definition
+			// keep track of # of aliases per fragment definition (memo cache, shared across operations)
 			visitedFragments := make(map[string]int)
+
+			// aliases is declared per-operation inside OnOperation so it doesn't accumulate across
+			// multiple operation definitions in the same document.
+			var operationFragmentAliases int
 
 			observers.OnFragmentSpread(func(_ *validator.Walker, fragmentSpread *ast.FragmentSpread) {
 				definition := fragmentSpread.Definition
@@ -54,11 +57,12 @@ func NewMaxAliasesRule(cfg Config, rules *validatorrules.Rules) {
 					visitedFragments[definition.Name] = count
 				}
 
-				aliases += visitedFragments[definition.Name]
+				operationFragmentAliases += visitedFragments[definition.Name]
 			})
 
 			observers.OnOperation(func(_ *validator.Walker, operation *ast.OperationDefinition) {
-				aliases += countAliases(operation)
+				aliases := countAliases(operation) + operationFragmentAliases
+				operationFragmentAliases = 0 // reset for next operation
 
 				maxAliases := cfg.Max
 				if override, ok := cfg.Overrides[operation.Name]; ok {

--- a/internal/business/rules/aliases/aliases_test.go
+++ b/internal/business/rules/aliases/aliases_test.go
@@ -223,3 +223,58 @@ type Book {
 		})
 	}
 }
+
+// Test_MaxAliasesRule_MultiOperationAccumulation verifies that the alias limit is enforced
+// per-operation and that the counter is not carried over between operations.
+func Test_MaxAliasesRule_MultiOperationAccumulation(t *testing.T) {
+	schemaStr := `
+type Query {
+   getBook(title: String): Book
+}
+
+type Book {
+	id: ID!
+	title: String
+	author: String
+}`
+
+	// Each operation has 6 aliases, limit is 10.
+	// A per-operation check should allow both; accumulated check would reject the second.
+	query := `
+query OpA {
+    a1: getBook(title: "1") { title }
+    a2: getBook(title: "2") { title }
+    a3: getBook(title: "3") { title }
+    a4: getBook(title: "4") { title }
+    a5: getBook(title: "5") { title }
+    a6: getBook(title: "6") { title }
+}
+query OpB {
+    b1: getBook(title: "1") { title }
+    b2: getBook(title: "2") { title }
+    b3: getBook(title: "3") { title }
+    b4: getBook(title: "4") { title }
+    b5: getBook(title: "5") { title }
+    b6: getBook(title: "6") { title }
+}`
+
+	cfg := Config{
+		Enabled:         true,
+		Max:             10,
+		RejectOnFailure: true,
+	}
+
+	rules := validatorrules.NewDefaultRules()
+	NewMaxAliasesRule(cfg, rules)
+
+	parsedQuery, _ := parser.ParseQuery(&ast.Source{Name: "ff", Input: query})
+	schema := gqlparser.MustLoadSchema(&ast.Source{
+		Name:    "graph/schema.graphqls",
+		Input:   schemaStr,
+		BuiltIn: false,
+	})
+
+	errs := validator.ValidateWithRules(schema, parsedQuery, rules)
+
+	assert.Empty(t, errs, "each operation has 6 aliases which is below the limit of 10; both should be allowed")
+}

--- a/internal/business/rules/block_field_suggestions/block_field_suggestions.go
+++ b/internal/business/rules/block_field_suggestions/block_field_suggestions.go
@@ -79,7 +79,7 @@ func (b *BlockFieldSuggestionsHandler) processError(err map[string]interface{}) 
 }
 
 func (b *BlockFieldSuggestionsHandler) replaceSuggestions(message string) string {
-	if strings.HasPrefix(message, "Did you mean") {
+	if strings.Contains(message, "Did you mean") {
 		resultCounter.WithLabelValues("masked").Inc()
 		return b.cfg.Mask
 	}

--- a/internal/business/rules/block_field_suggestions/block_field_suggestions_test.go
+++ b/internal/business/rules/block_field_suggestions/block_field_suggestions_test.go
@@ -64,12 +64,31 @@ func TestProcessBody(t *testing.T) {
 			},
 		},
 		{
-			name: "Replaces suggestions when found",
+			name: "Replaces suggestions when found at start of message",
 			args: args{
 				payload: map[string]interface{}{
 					"errors": []map[string]interface{}{
 						{
 							"message": "Did you mean 'foobar'?",
+						},
+					},
+				},
+			},
+			want: map[string]interface{}{
+				"errors": []map[string]interface{}{
+					{
+						"message": "[redacted]",
+					},
+				},
+			},
+		},
+		{
+			name: "Replaces suggestions when embedded mid-message (common gqlparser format)",
+			args: args{
+				payload: map[string]interface{}{
+					"errors": []map[string]interface{}{
+						{
+							"message": `Cannot query field "hell" on type "Query". Did you mean "hello"?`,
 						},
 					},
 				},

--- a/internal/business/schema/schema.go
+++ b/internal/business/schema/schema.go
@@ -7,6 +7,7 @@ import (
 	"github.com/vektah/gqlparser/v2/ast"
 	"log/slog"
 	"os"
+	"sync"
 	"time"
 )
 
@@ -45,6 +46,7 @@ func DefaultConfig() Config {
 
 type Provider struct {
 	cfg           Config
+	mu            sync.RWMutex
 	schema        *ast.Schema
 	done          chan bool
 	refreshTicker *time.Ticker
@@ -90,7 +92,9 @@ func (p *Provider) load(contents string) error {
 		return err
 	}
 
+	p.mu.Lock()
 	p.schema = schema
+	p.mu.Unlock()
 	return nil
 }
 
@@ -104,6 +108,8 @@ func (p *Provider) loadFromFs() error {
 }
 
 func (p *Provider) Get() *ast.Schema {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
 	return p.schema
 }
 

--- a/internal/business/schema/schema_test.go
+++ b/internal/business/schema/schema_test.go
@@ -1,0 +1,76 @@
+package schema
+
+import (
+	"log/slog"
+	"os"
+	"sync"
+	"testing"
+	"time"
+)
+
+func writeTempSchema(t *testing.T, content string) string {
+	t.Helper()
+	f, err := os.CreateTemp(t.TempDir(), "*.graphql")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.WriteString(content); err != nil {
+		t.Fatal(err)
+	}
+	f.Close()
+	return f.Name()
+}
+
+const minimalSchema = `type Query { hello: String }`
+
+func TestSchemaGetNoRaceWithReload(t *testing.T) {
+	path := writeTempSchema(t, minimalSchema)
+
+	cfg := Config{
+		Path: path,
+		AutoReload: struct {
+			Enabled  bool          `yaml:"enabled"`
+			Interval time.Duration `yaml:"interval"`
+		}{
+			Enabled: false, // we drive reloads manually below
+		},
+	}
+
+	p, err := NewSchema(cfg, slog.Default())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Writer goroutine: repeatedly calls loadFromFs (simulating what the reload ticker does).
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				_ = p.loadFromFs()
+			}
+		}
+	}()
+
+	// Reader goroutines: repeatedly call Get() concurrently with the writer.
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 500; j++ {
+				_ = p.Get()
+			}
+		}()
+	}
+
+	// Let readers finish, then stop the writer.
+	// (wg.Wait covers all goroutines, but we stop the writer after a short time)
+	time.Sleep(50 * time.Millisecond)
+	close(stop)
+	wg.Wait()
+}

--- a/internal/business/trusteddocuments/persisted_operations.go
+++ b/internal/business/trusteddocuments/persisted_operations.go
@@ -6,15 +6,16 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/ldebruijn/graphql-protect/internal/business/gql"
-	"github.com/ldebruijn/graphql-protect/internal/business/validation"
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/vektah/gqlparser/v2/gqlerror"
 	"io"
 	"log/slog"
 	"net/http"
 	"sync"
 	"time"
+
+	"github.com/ldebruijn/graphql-protect/internal/business/gql"
+	"github.com/ldebruijn/graphql-protect/internal/business/validation"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/vektah/gqlparser/v2/gqlerror"
 )
 
 var (
@@ -175,6 +176,13 @@ func (p *Handler) SwapHashForQuery(next http.Handler) http.Handler { // nolint:f
 		payload, err := gql.ParseRequestPayload(r)
 		if err != nil {
 			p.log.Warn("error decoding payload", "err", err)
+			if p.cfg.RejectOnFailure {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusBadRequest)
+				res, _ := json.Marshal(ErrorPayload{Errors: gqlerror.List{gqlerror.Wrap(err)}})
+				_, _ = w.Write(res)
+				return
+			}
 			next.ServeHTTP(w, r)
 			return
 		}
@@ -213,10 +221,10 @@ func (p *Handler) SwapHashForQuery(next http.Handler) http.Handler { // nolint:f
 
 		if len(errs) > 0 {
 			// if any error occurred we fail
-			res, _ := json.Marshal(ErrorPayload{
-				Errors: errs,
-			})
-			http.Error(w, string(res), 200)
+			res, _ := json.Marshal(ErrorPayload{Errors: errs})
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(res)
 			return
 		}
 
@@ -249,10 +257,14 @@ func (p *Handler) SwapHashForQuery(next http.Handler) http.Handler { // nolint:f
 }
 
 func (p *Handler) GetTrustedDocuments() map[string]PersistedOperation {
+	p.lock.RLock()
+	defer p.lock.RUnlock()
 	return p.cache
 }
 
 func (p *Handler) Validate(validate func(data gql.RequestData) gqlerror.List) []validation.Error {
+	p.lock.RLock()
+	defer p.lock.RUnlock()
 	var errs []validation.Error
 	for hash, operation := range p.cache {
 		data := gql.RequestData{
@@ -282,9 +294,11 @@ func (p *Handler) load(failureStrategy ReloadFailureStrategy) error {
 		// implicit fall through for other failure types
 	}
 
-	p.lock.Lock()
-	p.cache = newState
-	p.lock.Unlock()
+	if newState != nil {
+		p.lock.Lock()
+		p.cache = newState
+		p.lock.Unlock()
+	}
 
 	p.log.Info(fmt.Sprintf("Total number of unique operation hashes: %d", len(newState)))
 	uniqueHashesInMemGauge.WithLabelValues().Set(float64(len(newState)))

--- a/internal/business/trusteddocuments/persisted_operations_test.go
+++ b/internal/business/trusteddocuments/persisted_operations_test.go
@@ -5,13 +5,18 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+
 	"github.com/ldebruijn/graphql-protect/internal/business/gql"
 	"github.com/stretchr/testify/assert"
+	"github.com/vektah/gqlparser/v2/gqlerror"
+
 	"io"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
+	"time"
 )
 
 func TestNewPersistedOperations(t *testing.T) {
@@ -202,6 +207,53 @@ func TestNewPersistedOperations(t *testing.T) {
 			},
 		},
 		{
+			name: "returns application/json Content-Type on persisted operation error",
+			args: args{
+				cfg: Config{
+					Enabled:         true,
+					RejectOnFailure: false,
+				},
+				payload: func() []byte {
+					data := gql.RequestData{
+						Extensions: gql.Extensions{
+							PersistedQuery: &gql.PersistedQuery{
+								Sha256Hash: "unknown-hash",
+							},
+						},
+					}
+					bts, _ := json.Marshal(data)
+					return bts
+				}(),
+				cache: map[string]PersistedOperation{},
+			},
+			want: func(_ *testing.T) http.Handler {
+				return http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {})
+			},
+			resWant: func(t *testing.T, res *http.Response) {
+				assert.Equal(t, 200, res.StatusCode)
+				assert.Equal(t, "application/json", res.Header.Get("Content-Type"))
+			},
+		},
+		{
+			name: "rejects request on parse error when trusted documents is enabled",
+			args: args{
+				cfg: Config{
+					Enabled:         true,
+					RejectOnFailure: true,
+				},
+				payload: []byte(`not valid json`),
+			},
+			want: func(t *testing.T) http.Handler {
+				fn := func(_ http.ResponseWriter, _ *http.Request) {
+					assert.Fail(t, "upstream should not be called when parse fails with trusted docs enabled")
+				}
+				return http.HandlerFunc(fn)
+			},
+			resWant: func(t *testing.T, res *http.Response) {
+				assert.Equal(t, 400, res.StatusCode)
+			},
+		},
+		{
 			name: "fails entire batch if one operation is unknown",
 			args: args{
 				cfg: Config{
@@ -241,7 +293,7 @@ func TestNewPersistedOperations(t *testing.T) {
 				assert.Equal(t, 200, res.StatusCode)
 				payload, err := io.ReadAll(res.Body)
 				assert.NoError(t, err)
-				assert.Equal(t, "{\"errors\":[{\"message\":\"PersistedOperationNotFound\"}]}\n", string(payload))
+				assert.Equal(t, "{\"errors\":[{\"message\":\"PersistedOperationNotFound\"}]}", string(payload))
 			},
 		},
 	}
@@ -405,6 +457,120 @@ func TestLoader(t *testing.T) {
 			assert.Equal(t, tt.want, po.cache)
 		})
 	}
+}
+
+// TestLoadNilDoesNotWipeCache verifies that a loader returning (nil, err) with the Ignore
+// strategy does not overwrite the existing in-memory cache.
+func TestLoadNilDoesNotWipeCache(t *testing.T) {
+	existing := map[string]PersistedOperation{
+		"abc": {Operation: "{ existing }", Name: "existing"},
+	}
+	nilLoader := &testLoader{
+		data:            nil,
+		err:             errors.New("storage unavailable"),
+		willReturnError: true,
+	}
+	po, err := NewPersistedOperations(slog.Default(), Config{}, nilLoader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	po.cache = existing
+
+	_ = po.load(ReloadFailureStrategyIgnore)
+
+	if po.cache == nil {
+		t.Fatal("load() with nil newState and Ignore strategy wiped the existing cache")
+	}
+	if _, ok := po.cache["abc"]; !ok {
+		t.Errorf("existing cache entry was removed after failed load; cache is now %v", po.cache)
+	}
+}
+
+// TestGetTrustedDocumentsNoRace exercises GetTrustedDocuments concurrently with
+// cache writes to expose the missing lock (run with -race).
+func TestGetTrustedDocumentsNoRace(t *testing.T) {
+	loader := newMemoryLoader(map[string]PersistedOperation{
+		"h1": {Operation: "{ q }", Name: "q"},
+	})
+	po, err := NewPersistedOperations(slog.Default(), Config{}, loader)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				po.lock.Lock()
+				po.cache = map[string]PersistedOperation{"h2": {Operation: "{ q2 }", Name: "q2"}}
+				po.lock.Unlock()
+			}
+		}
+	}()
+
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 300; j++ {
+				_ = po.GetTrustedDocuments()
+			}
+		}()
+	}
+
+	time.Sleep(30 * time.Millisecond)
+	close(stop)
+	wg.Wait()
+}
+
+// TestValidateNoRace exercises Validate concurrently with cache writes to expose the missing lock.
+func TestValidateNoRace(t *testing.T) {
+	loader := newMemoryLoader(map[string]PersistedOperation{
+		"h1": {Operation: "{ q }", Name: "q"},
+	})
+	po, err := NewPersistedOperations(slog.Default(), Config{}, loader)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				po.lock.Lock()
+				po.cache = map[string]PersistedOperation{"h2": {Operation: "{ q2 }", Name: "q2"}}
+				po.lock.Unlock()
+			}
+		}
+	}()
+
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 50; j++ {
+				_ = po.Validate(func(_ gql.RequestData) gqlerror.List { return nil })
+			}
+		}()
+	}
+
+	time.Sleep(30 * time.Millisecond)
+	close(stop)
+	wg.Wait()
 }
 
 var _ Loader = &testLoader{}

--- a/makefile
+++ b/makefile
@@ -22,7 +22,7 @@ x-build:
 
 .PHONY: test
 test:
-	go test -v ./...
+	go test -race -v ./...
 
 .PHONY: lint
 ## Runs a linter over the code


### PR DESCRIPTION
Security fixes, data races, and correctness bugs found through a full codebase audit.

## Security

- Chunked encoding bypass: ContentLength < 1 treated chunked bodies (-1) as empty, skipping all protection rules. Fixed to == 0.
- Field suggestions leak from protect layer: block_field_suggestions only scrubbed upstream responses; the protect layer's own validation errors still contained Did you mean hints. The FieldsOnCorrectType rule is now swapped for its WithoutSuggestions variant when the feature is enabled.
- block_field_suggestions missed embedded suggestions: scrubber used HasPrefix("Did you mean"), missing the common Cannot query field X. Did you mean Y? format. Changed to Contains.
- WebSocket upgrade bypass: Upgrade: websocket requests were proxied transparently, bypassing every protection rule. Now rejected with 400 as websockets are not supported.

## Data races

- schema.Provider: concurrent Get() / load() on the schema field was unprotected. Added sync.RWMutex.
- trusteddocuments.Handler: GetTrustedDocuments() and Validate() read the cache without holding the read lock. Both now acquire RLock.
- Cache nil wipe: a total loader failure returned nil, wiping the in-memory cache and failing all lookups until the next successful reload. Cache is now only replaced when the new state is non-nil.

## Bug fixes

- Whitespace-only body panic: body trimmed to empty then indexed at [0]. Added length guard after trim.
- Alias counter accumulated across operations: counter was shared across OnOperation calls in a multi-operation document, causing valid operations to be incorrectly rejected.
- Trusted documents parse error forwarded to upstream: with reject_on_failure: true, malformed payloads were forwarded instead of rejected with 400.
- Trusted documents error response Content-Type: was text/plain (via http.Error), now application/json.

## Internal
  
- -race added to make test.