### PR TITLE
feat(access-logs): make GCP log buffer size configurable and count drops

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -159,6 +159,8 @@ access_logging:
     project_id: ""
     # Log name in GCP (defaults to "graphql-protect-access-logs")
     log_name: ""
+    # Max in-memory buffer size for pending GCP log entries, in MB (defaults to 1000 ≈ 1GiB)
+    log_buffer_max_size_mb: 1000
 ```
 
 For a more in-depth view of each option visit the accompanying documentation page of each individual protection.

--- a/docs/protections/access_logging.md
+++ b/docs/protections/access_logging.md
@@ -74,6 +74,8 @@ access_logging:
     project_id: "my-gcp-project"
     # Log name in Google Cloud Logging (optional, defaults to "graphql-protect-access-logs")
     log_name: "graphql-protect-access-logs"
+    # Max in-memory buffer size for pending GCP log entries, in MB (defaults to 1000 ≈ 1GiB)
+    log_buffer_max_size_mb: 1000
 ```
 
 **Note**: When `google_cloud_logging.enabled: true`, the `async` option is automatically disabled (even if set to true). The GCP Cloud Logging client handles batching internally.
@@ -101,6 +103,7 @@ Access logging provides the following Prometheus metrics:
 
 - `graphql_protect_access_logging_gcp_writes_total` - Total number of access log entries written to Google Cloud Logging
 - `graphql_protect_access_logging_gcp_errors_total` - Total number of errors encountered while writing to Google Cloud Logging
+- `graphql_protect_access_logging_gcp_dropped_total` - Total number of messages dropped while writing to Google Cloud Logging
 
 These metrics help you monitor the health and performance of your access logging system.
 

--- a/examples/config-with-gcp-logging.yml
+++ b/examples/config-with-gcp-logging.yml
@@ -52,6 +52,8 @@ access_logging:
     # Log name in Google Cloud Logging
     # Defaults to "graphql-protect-access-logs" if not specified
     log_name: "graphql-protect-access-logs"
+    # Max in-memory buffer size for pending GCP log entries, in MB (defaults to 1000 ≈ 1GiB)
+    log_buffer_max_size_mb: 1000
 
 # Note: With google_cloud_logging.enabled: true
 # - Access logs go to Google Cloud Logging
@@ -59,6 +61,7 @@ access_logging:
 # - Monitor using Prometheus metrics:
 #   - graphql_protect_access_logging_gcp_writes_total
 #   - graphql_protect_access_logging_gcp_errors_total
+#   - graphql_protect_access_logging_gcp_dropped_total
 
 obfuscate_validation_errors: false
 obfuscate_upstream_errors: true

--- a/internal/app/config/config_test.go
+++ b/internal/app/config/config_test.go
@@ -215,6 +215,9 @@ log:
 					IncludePayload:       true,
 					Async:                false,
 					BufferSize:           1000,
+					GoogleCloudLogging: accesslogging.GoogleCloudConfig{
+						BufferedByteLimit: 1000,
+					},
 				},
 				Log: log.Config{
 					Format: log.TextFormat,

--- a/internal/business/rules/accesslogging/config.go
+++ b/internal/business/rules/accesslogging/config.go
@@ -14,9 +14,10 @@ type Config struct {
 
 // GoogleCloudConfig represents Google Cloud Logging configuration
 type GoogleCloudConfig struct {
-	Enabled   bool   `yaml:"enabled"`
-	ProjectID string `yaml:"project_id"`
-	LogName   string `yaml:"log_name"`
+	Enabled           bool   `yaml:"enabled"`
+	ProjectID         string `yaml:"project_id"`
+	LogName           string `yaml:"log_name"`
+	BufferedByteLimit int    `yaml:"log_buffer_max_size_mb"`
 }
 
 // DefaultConfig returns default configuration for access logging
@@ -30,9 +31,10 @@ func DefaultConfig() Config {
 		Async:                false,
 		BufferSize:           1000,
 		GoogleCloudLogging: GoogleCloudConfig{
-			Enabled:   false,
-			ProjectID: "",
-			LogName:   "",
+			Enabled:           false,
+			ProjectID:         "",
+			LogName:           "",
+			BufferedByteLimit: 1000,
 		},
 	}
 }

--- a/internal/business/rules/accesslogging/config_test.go
+++ b/internal/business/rules/accesslogging/config_test.go
@@ -1,0 +1,61 @@
+package accesslogging
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	yaml "gopkg.in/yaml.v3"
+)
+
+func TestDefaultConfig(t *testing.T) {
+	cfg := DefaultConfig()
+
+	assert.True(t, cfg.Enabled)
+	assert.True(t, cfg.IncludeOperationName)
+	assert.True(t, cfg.IncludeVariables)
+	assert.False(t, cfg.IncludePayload)
+	assert.False(t, cfg.Async)
+	assert.Equal(t, 1000, cfg.BufferSize)
+
+	gcp := cfg.GoogleCloudLogging
+	assert.False(t, gcp.Enabled)
+	assert.Empty(t, gcp.ProjectID)
+	assert.Empty(t, gcp.LogName)
+	// Preserves the previous GCP client default (1000 MB ≈ 1GiB) so upgrades are behaviour-neutral.
+	assert.Equal(t, 1000, gcp.BufferedByteLimit)
+}
+
+// TestGoogleCloudConfig_YAMLBinding guards the yaml tag names against typos:
+// a wrong tag would silently leave fields at their zero value.
+func TestGoogleCloudConfig_YAMLBinding(t *testing.T) {
+	raw := []byte(`
+enabled: true
+project_id: "my-gcp-project"
+log_name: "my-logs"
+log_buffer_max_size_mb: 256
+`)
+
+	var cfg GoogleCloudConfig
+	require.NoError(t, yaml.Unmarshal(raw, &cfg))
+
+	assert.True(t, cfg.Enabled)
+	assert.Equal(t, "my-gcp-project", cfg.ProjectID)
+	assert.Equal(t, "my-logs", cfg.LogName)
+	assert.Equal(t, 256, cfg.BufferedByteLimit)
+}
+
+// TestGoogleCloudConfig_YAMLOmittedKeepsDefault documents that unmarshalling over a
+// pre-populated struct (as the loader does after DefaultConfig) preserves the default
+// when log_buffer_max_size_mb is omitted.
+func TestGoogleCloudConfig_YAMLOmittedKeepsDefault(t *testing.T) {
+	cfg := DefaultConfig().GoogleCloudLogging
+
+	raw := []byte(`
+enabled: true
+project_id: "my-gcp-project"
+`)
+	require.NoError(t, yaml.Unmarshal(raw, &cfg))
+
+	assert.Equal(t, 1000, cfg.BufferedByteLimit)
+}

--- a/internal/business/rules/accesslogging/writer_gcp.go
+++ b/internal/business/rules/accesslogging/writer_gcp.go
@@ -26,10 +26,17 @@ var (
 		Name:      "gcp_errors_total",
 		Help:      "The total number of errors encountered while writing to Google Cloud Logging",
 	})
+
+	gcpDroppedCounter = prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace: "graphql_protect",
+		Subsystem: "access_logging",
+		Name:      "gcp_dropped_total",
+		Help:      "The total number of messages dropped while writing to Google Cloud Logging",
+	})
 )
 
 func init() {
-	prometheus.MustRegister(gcpWritesCounter, gcpErrorsCounter)
+	prometheus.MustRegister(gcpWritesCounter, gcpErrorsCounter, gcpDroppedCounter)
 }
 
 // GoogleCloudWriter writes access logs to Google Cloud Logging
@@ -57,7 +64,15 @@ func NewGoogleCloudWriter(cfg GoogleCloudConfig, log *slog.Logger) (*GoogleCloud
 		logName = "graphql-protect-access-logs"
 	}
 
-	logger := client.Logger(logName)
+	logger := client.Logger(logName, logging.BufferedByteLimit(cfg.BufferedByteLimit<<20))
+	client.OnError = func(err error) {
+		if errors.Is(err, logging.ErrOverflow) {
+			gcpDroppedCounter.Inc()
+			return
+		}
+		gcpErrorsCounter.Inc()
+		log.Warn("Google Cloud Logging error", "err", err)
+	}
 
 	log.Info("Google Cloud Logging initialized",
 		"project_id", projectID,


### PR DESCRIPTION
## Problem

The Google Cloud Logging client buffers pending log entries in memory . Its default `BufferedByteLimit` is **1GiB**. When the Cloud Logging flush slows down, the buffer grows unbounded.  Drops on the GCP path were also completely silent (no metric, no log).

## Changes

- **Configurable buffer size** via `log_buffer_max_size_mb` (default `1000`, i.e. ~1GiB — preserves current behaviour). Wired into `logging.BufferedByteLimit`. Operators can now bound it below the container memory limit so the bundler drops entries instead of OOMing.
- **`graphql_protect_access_logging_gcp_dropped_total`** counter — increments when the bundler returns `ErrOverflow`, so drops are observable.
- **Error logging on `OnError`** — non-overflow async errors now increment `gcp_errors_total` and emit a warning, instead of being swallowed.
- Docs + example config updated.

## Tests

- `TestDefaultConfig` — asserts the buffer default stays `1000` (behaviour-neutral upgrade).
- `TestGoogleCloudConfig_YAMLBinding` — guards the YAML tag name against typos.
- `TestGoogleCloudConfig_YAMLOmittedKeepsDefault` — omitted key preserves the default when unmarshalling over `DefaultConfig()`.

`go vet` clean, full package test suite passes.