### PR TITLE
feat(schema): add GCS bucket loader with auto-reload

### DIFF
--- a/internal/app/config/config_test.go
+++ b/internal/app/config/config_test.go
@@ -139,7 +139,8 @@ log:
 				ObfuscateValidationErrors: true,
 				ObfuscateUpstreamErrors:   false,
 				Schema: schema.Config{
-					Path: "path",
+					Path:   "path",
+					Loader: schema.LoaderConfig{Type: "local"},
 					AutoReload: struct {
 						Enabled  bool          `yaml:"enabled"`
 						Interval time.Duration `yaml:"interval"`

--- a/internal/business/schema/gcp_loader.go
+++ b/internal/business/schema/gcp_loader.go
@@ -1,0 +1,73 @@
+package schema
+
+import (
+	"cloud.google.com/go/storage"
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"time"
+)
+
+// objectReader abstracts reading a single GCS object, allowing test injection.
+type objectReader interface {
+	read(ctx context.Context) (string, error)
+}
+
+type gcsObjectReader struct {
+	client *storage.Client
+	bucket string
+	object string
+}
+
+func (r *gcsObjectReader) read(ctx context.Context) (string, error) {
+	ctx, cancel := context.WithTimeout(ctx, 50*time.Second)
+	defer cancel()
+
+	reader, err := r.client.Bucket(r.bucket).Object(r.object).NewReader(ctx)
+	if err != nil {
+		return "", fmt.Errorf("Object(%q).NewReader: %w", r.object, err)
+	}
+	defer reader.Close()
+
+	data, err := io.ReadAll(reader)
+	if err != nil {
+		return "", fmt.Errorf("io.ReadAll: %w", err)
+	}
+
+	return string(data), nil
+}
+
+type gcpSchemaLoader struct {
+	reader objectReader
+	bucket string
+	object string
+	log    *slog.Logger
+}
+
+func newGcpSchemaLoader(bucket, object string, log *slog.Logger) (*gcpSchemaLoader, error) {
+	client, err := storage.NewClient(context.Background())
+	if err != nil {
+		return nil, err
+	}
+
+	return &gcpSchemaLoader{
+		reader: &gcsObjectReader{
+			client: client,
+			bucket: bucket,
+			object: object,
+		},
+		bucket: bucket,
+		object: object,
+		log:    log,
+	}, nil
+}
+
+func (g *gcpSchemaLoader) fetch() (string, error) {
+	contents, err := g.reader.read(context.Background())
+	if err != nil {
+		return "", err
+	}
+	g.log.Info("Loaded schema from GCS", "bucket", g.bucket, "object", g.object)
+	return contents, nil
+}

--- a/internal/business/schema/gcp_loader_test.go
+++ b/internal/business/schema/gcp_loader_test.go
@@ -1,0 +1,105 @@
+package schema
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type mockObjectReader struct {
+	content string
+	err     error
+}
+
+func (m *mockObjectReader) read(_ context.Context) (string, error) {
+	return m.content, m.err
+}
+
+func newMockGcpSchemaLoader(content string, err error) *gcpSchemaLoader {
+	return &gcpSchemaLoader{
+		reader: &mockObjectReader{content: content, err: err},
+		bucket: "test-bucket",
+		object: "schema.graphql",
+		log:    slog.Default(),
+	}
+}
+
+func TestGcpSchemaLoader_Fetch(t *testing.T) {
+	tests := []struct {
+		name        string
+		content     string
+		readerErr   error
+		wantContent string
+		wantErr     bool
+	}{
+		{
+			name:        "returns schema content on success",
+			content:     minimalSchema,
+			wantContent: minimalSchema,
+		},
+		{
+			name:      "propagates reader error",
+			readerErr: errors.New("gcs read failed"),
+			wantErr:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			loader := newMockGcpSchemaLoader(tt.content, tt.readerErr)
+
+			got, err := loader.fetch()
+
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantContent, got)
+		})
+	}
+}
+
+func TestProvider_WithGcpLoader(t *testing.T) {
+	// Verifies the wiring between gcpSchemaLoader and Provider without real GCS credentials.
+	// This mirrors exactly what NewSchema does when loader.type == "gcp".
+	p := &Provider{
+		done: make(chan bool, 1),
+		log:  slog.Default(),
+	}
+
+	gcpLoader := newMockGcpSchemaLoader(minimalSchema, nil)
+	p.loadFn = func() error {
+		contents, err := gcpLoader.fetch()
+		if err != nil {
+			return err
+		}
+		return p.load(contents)
+	}
+
+	require.NoError(t, p.loadFn())
+	assert.NotNil(t, p.Get())
+}
+
+func TestProvider_WithGcpLoader_FetchError(t *testing.T) {
+	p := &Provider{
+		done: make(chan bool, 1),
+		log:  slog.Default(),
+	}
+
+	gcpLoader := newMockGcpSchemaLoader("", errors.New("bucket not found"))
+	p.loadFn = func() error {
+		contents, err := gcpLoader.fetch()
+		if err != nil {
+			return err
+		}
+		return p.load(contents)
+	}
+
+	assert.Error(t, p.loadFn())
+	assert.Nil(t, p.Get())
+}

--- a/internal/business/schema/schema.go
+++ b/internal/business/schema/schema.go
@@ -20,8 +20,14 @@ var reloadGauge = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 },
 	[]string{"state"})
 
+type LoaderConfig struct {
+	Type     string `yaml:"type"`     // "local" (default) or "gcp"
+	Location string `yaml:"location"` // GCS bucket name when type is "gcp"
+}
+
 type Config struct {
-	Path       string `yaml:"path"`
+	Path       string       `yaml:"path"`
+	Loader     LoaderConfig `yaml:"loader"`
 	AutoReload struct {
 		Enabled  bool          `yaml:"enabled"`
 		Interval time.Duration `yaml:"interval"`
@@ -31,6 +37,9 @@ type Config struct {
 func DefaultConfig() Config {
 	return Config{
 		Path: "./schema.graphql",
+		Loader: LoaderConfig{
+			Type: "local",
+		},
 		AutoReload: struct {
 			Enabled  bool          `yaml:"enabled"`
 			Interval time.Duration `yaml:"interval"`
@@ -51,6 +60,7 @@ type Provider struct {
 	done          chan bool
 	refreshTicker *time.Ticker
 	log           *slog.Logger
+	loadFn        func() error
 }
 
 func NewSchema(cfg Config, log *slog.Logger) (*Provider, error) {
@@ -61,7 +71,7 @@ func NewSchema(cfg Config, log *slog.Logger) (*Provider, error) {
 		return time.NewTicker(cfg.AutoReload.Interval)
 	}()
 
-	p := Provider{
+	p := &Provider{
 		cfg: cfg,
 		// nil until we load
 		schema: nil,
@@ -71,15 +81,31 @@ func NewSchema(cfg Config, log *slog.Logger) (*Provider, error) {
 		log:           log,
 	}
 
-	err := p.loadFromFs()
-	if err != nil {
-		return nil, fmt.Errorf("unable to load schema from disk [%s]: %w", p.cfg.Path, err)
+	switch cfg.Loader.Type {
+	case "gcp":
+		gcpLoader, err := newGcpSchemaLoader(cfg.Loader.Location, cfg.Path, log)
+		if err != nil {
+			return nil, fmt.Errorf("unable to create GCP schema loader: %w", err)
+		}
+		p.loadFn = func() error {
+			contents, err := gcpLoader.fetch()
+			if err != nil {
+				return err
+			}
+			return p.load(contents)
+		}
+	default:
+		p.loadFn = p.loadFromFs
+	}
+
+	if err := p.loadFn(); err != nil {
+		return nil, fmt.Errorf("unable to load schema [%s]: %w", cfg.Path, err)
 	}
 
 	// initiate auto reloading
 	p.reload()
 
-	return &p, nil
+	return p, nil
 }
 
 func (p *Provider) load(contents string) error {
@@ -102,7 +128,6 @@ func (p *Provider) loadFromFs() error {
 	contents, err := os.ReadFile(p.cfg.Path)
 	if err != nil {
 		return err
-
 	}
 	return p.load(string(contents))
 }
@@ -124,9 +149,9 @@ func (p *Provider) reload() {
 			case <-p.done:
 				return
 			case <-p.refreshTicker.C:
-				err := p.loadFromFs()
+				err := p.loadFn()
 				if err != nil {
-					p.log.Warn("Error loading from local dir", "err", err)
+					p.log.Warn("Error reloading schema", "err", err)
 					reloadGauge.WithLabelValues("failed").Inc()
 					continue
 				}

--- a/internal/business/schema/schema_test.go
+++ b/internal/business/schema/schema_test.go
@@ -6,6 +6,9 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func writeTempSchema(t *testing.T, content string) string {
@@ -22,6 +25,61 @@ func writeTempSchema(t *testing.T, content string) string {
 }
 
 const minimalSchema = `type Query { hello: String }`
+
+func TestNewSchema_PathOnly(t *testing.T) {
+	// Backward-compat: Config with only Path set (no Loader field) must load from the filesystem.
+	path := writeTempSchema(t, minimalSchema)
+
+	p, err := NewSchema(Config{Path: path}, slog.Default())
+
+	require.NoError(t, err)
+	assert.NotNil(t, p.Get())
+}
+
+func TestNewSchema_ExplicitLocalLoader(t *testing.T) {
+	path := writeTempSchema(t, minimalSchema)
+
+	cfg := Config{
+		Path:   path,
+		Loader: LoaderConfig{Type: "local"},
+	}
+
+	p, err := NewSchema(cfg, slog.Default())
+
+	require.NoError(t, err)
+	assert.NotNil(t, p.Get())
+}
+
+func TestNewSchema_UnknownLoaderTypeFallsBackToLocal(t *testing.T) {
+	// Any unrecognised loader type falls back to local file loading.
+	path := writeTempSchema(t, minimalSchema)
+
+	cfg := Config{
+		Path:   path,
+		Loader: LoaderConfig{Type: "s3"},
+	}
+
+	p, err := NewSchema(cfg, slog.Default())
+
+	require.NoError(t, err)
+	assert.NotNil(t, p.Get())
+}
+
+func TestNewSchema_FileNotFound(t *testing.T) {
+	cfg := Config{Path: "/nonexistent/schema.graphql"}
+
+	_, err := NewSchema(cfg, slog.Default())
+
+	assert.Error(t, err)
+}
+
+func TestNewSchema_InvalidGraphQL(t *testing.T) {
+	path := writeTempSchema(t, "this is not valid graphql {{{")
+
+	_, err := NewSchema(Config{Path: path}, slog.Default())
+
+	assert.Error(t, err)
+}
 
 func TestSchemaGetNoRaceWithReload(t *testing.T) {
 	path := writeTempSchema(t, minimalSchema)


### PR DESCRIPTION
## Summary

- Adds a `loader` config block to the schema configuration (`type: local|gcp`, `location: <bucket-name>`), mirroring the existing GCS loader for trusted documents
- When `type: gcp` is set, the schema is fetched from the specified GCS bucket; the existing `path` field doubles as the object path within the bucket
- Auto-reload fires on the configured interval for both local and GCS backends
- Existing configs with only `path` set remain fully backward-compatible (the `default` switch case falls back to local file loading)
- Fixes the config integration test whose `want` struct predated the new `Loader` field and was asserting the zero value instead of the `"local"` default

## Configuration example

```yaml
schema:
  loader:
    type: gcp
    location: my-gcs-bucket   # bucket name
  path: schemas/schema.graphql # object path within the bucket
  auto_reload:
    enabled: true
    interval: 30s
```

## Test plan

- [ ] `TestNewSchema_PathOnly` — path-only config (no `loader` field) loads from disk
- [ ] `TestNewSchema_ExplicitLocalLoader` — explicit `type: local` works
- [ ] `TestNewSchema_UnknownLoaderTypeFallsBackToLocal` — unrecognised type falls back to local
- [ ] `TestNewSchema_FileNotFound` / `TestNewSchema_InvalidGraphQL` — error cases
- [ ] `TestGcpSchemaLoader_Fetch` — GCS fetch happy path and error with mock reader
- [ ] `TestProvider_WithGcpLoader` / `TestProvider_WithGcpLoader_FetchError` — full Provider + GCS wiring with mock reader
- [ ] `TestNewConfig/YAML_overrides_are_applied` — config test updated to expect `Loader.Type: "local"` default

PR created using Claude Code